### PR TITLE
removed duplicate key description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,6 @@ description: Asset Management Library for Dart Games
 version: 0.6.2
 authors:
 - John McCutchan <john@johnmccutchan.com>
-description: Asset Management Library for Dart Games
 homepage: https://github.com/johnmccutchan/asset_pack
 dev_dependencies:
   unittest: any


### PR DESCRIPTION
There has been a change in the parser, which makes this pubspec invalid. Thus projects using this dependency fail when executing pub.

https://github.com/dart-lang/yaml/pull/22